### PR TITLE
リブログ時の公開範囲にDMを許可

### DIFF
--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -90,7 +90,7 @@ class Status < ApplicationRecord
   validates_with StatusLengthValidator
   validates_with DisallowedHashtagsValidator
   validates :reblog, uniqueness: { scope: :account }, if: :reblog?
-  validates :visibility, exclusion: { in: %w(direct limited) }, if: :reblog?
+  validates :visibility, exclusion: { in: %w(limited) }, if: :reblog?
 
   accepts_nested_attributes_for :poll
 


### PR DESCRIPTION
#2 の残作業
デフォルト公開範囲がDMになっているとリブログ時にエラーになるのを修正