### PR TITLE
リモートアカウントを作成する時に設定されているピン留めノートとタグを取得しない

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,7 +85,8 @@ COPY --chown=mastodon:mastodon --from=build /opt/mastodon /opt/mastodon
 ENV RAILS_ENV="production" \
     NODE_ENV="production" \
     RAILS_SERVE_STATIC_FILES="true" \
-    BIND="0.0.0.0"
+    BIND="0.0.0.0" \
+    NODE_OPTIONS=--openssl-legacy-provider
 
 # Set the run user
 USER mastodon

--- a/app/services/activitypub/process_account_service.rb
+++ b/app/services/activitypub/process_account_service.rb
@@ -107,7 +107,7 @@ class ActivityPub::ProcessAccountService < BaseService
   end
 
   def set_immediate_attributes!
-    @account.featured_collection_url = @json['featured'] || ''
+    @account.featured_collection_url = ''
     @account.devices_url             = @json['devices'] || ''
     @account.display_name            = @json['name'] || ''
     @account.note                    = @json['summary'] || ''


### PR DESCRIPTION
- リモートのカスタム絵文字がDLされてしまうの防止